### PR TITLE
Moved index code to init-containers, deleted auxiliary js script.

### DIFF
--- a/scripts/auxiliary_SetIndexes.js
+++ b/scripts/auxiliary_SetIndexes.js
@@ -1,5 +1,0 @@
-db.tf.ensureIndex( { __recorded : 1 } )
-db.tf.ensureIndex( { "transforms.header.stamp" : 1 } )
-db.logged_designators.ensureIndex( { __recorded : 1 } )
-
-

--- a/scripts/init-containers
+++ b/scripts/init-containers
@@ -68,5 +68,8 @@ mongoimport --db roslog --collection logged_designators logged_designators.json
 
 # set mongo indexes:
 cd $MY_PATH
-mongo roslog auxiliary_SetIndexes.js
+
+mongo roslog --eval "db.tf.ensureIndex( { __recorded : 1 } )"
+mongo roslog --eval "db.tf.ensureIndex( { 'transforms.header.stamp' : 1 } )"
+mongo roslog --eval "db.logged_designators.ensureIndex( { __recorded : 1 } )"
 


### PR DESCRIPTION
Minor, and very late fix, sorry. I somehow missed the notification on the comment for the previous pull request, but here it is. Indexing code now moved to init-containers, for more elegance.
