### PR TITLE
Prepare webrob for ssl.

### DIFF
--- a/webrob/webrob/templates/editor.html
+++ b/webrob/webrob/templates/editor.html
@@ -40,8 +40,9 @@
 
     function init() {
       // Connect to ROS.
+      wsproto = 'ws' + (location.protocol === 'https:'?'s':'');
       ros = new ROSLIB.Ros({
-        url : 'ws://{{ host_url }}/ws/{{ container_name }}/'
+        url : wsproto + '://{{ host_url }}/ws/{{ container_name }}/'
       });
       
       // 'change' event is triggered whenever the editor content changes

--- a/webrob/webrob/templates/knowrob.html
+++ b/webrob/webrob/templates/knowrob.html
@@ -71,8 +71,9 @@
           %}{{ url_for('static', filename='queries.json') }}{%
       endif %}";
       
+      wsproto = 'ws' + (location.protocol === 'https:'?'s':'');
       knowrob = new Knowrob({
-          ros_url: 'ws://{{ host_url }}/ws/{{ container_name }}/',
+          ros_url: wsproto + '://{{ host_url }}/ws/{{ container_name }}/',
           library_file: libraryFile
       });
       knowrob.init();

--- a/webrob/webrob/templates/layout.html
+++ b/webrob/webrob/templates/layout.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8" />
-  <link rel="stylesheet" media="all" type="text/css" href="http://fonts.googleapis.com/css?family=Open+Sans:400,400italic,700|Oswald|Source+Code+Pro" />
+  <link rel="stylesheet" media="all" type="text/css" href="//fonts.googleapis.com/css?family=Open+Sans:400,400italic,700|Oswald|Source+Code+Pro" />
   <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='lib/screen.css') }}"/>
   <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='overlay/iosOverlay.css') }}"/>
   <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='overlay/prettify.css') }}"/>


### PR DESCRIPTION
Webrob has some URLs for external assets hardcoded to unencrypted protocols like ws or http.
This PR makes any external assets work with both encrypted and unencrypted connections.