### PR TITLE
Timeout for user containers.

### DIFF
--- a/dockerbridge/dockerbridge.py
+++ b/dockerbridge/dockerbridge.py
@@ -6,142 +6,39 @@
     Always sanitize method parameters in methods with @pyjsonrpc.rpcmethod annotation where necessary, as they contain
     user input.
 """
-import traceback
 import signal
 import sys
-from requests import ConnectionError
 
-import docker
-from docker.errors import *
 import pyjsonrpc
 
-
-def docker_connect():
-    c = docker.Client(base_url='unix://var/run/docker.sock', version='1.12', timeout=10)
-    return c
+from dockermanager import DockerManager
+from timeoutmanager import TimeoutManager
+from utils import sysout
 
 
 class DockerBridge(pyjsonrpc.HttpRequestHandler):
     @pyjsonrpc.rpcmethod
     def start_container(self, user_container_name, user_data_container_name, common_data_container_name):
-
-        try:
-            c = docker_connect()
-
-            if c is not None:
-
-                all_containers = c.containers(all=True)
-
-                # check if containers exist:
-                user_cont_exists = False
-                user_data_cont_exists = False
-                common_data_exists = False
-                mongo_cont_exists = False
-
-                for cont in all_containers:
-                    if "/" + user_container_name in cont['Names']:
-                        user_cont_exists = True
-                    if "/" + user_data_container_name in cont['Names']:
-                        user_data_cont_exists = True
-                    if "/" + common_data_container_name in cont['Names']:
-                        common_data_exists = True
-                    if "/mongo_db" in cont['Names']:
-                        mongo_cont_exists = True
-
-                # Create containers if they do not exist yet
-                if not user_cont_exists:
-                    env = {"VIRTUAL_HOST": user_container_name,
-                           "VIRTUAL_PORT": '9090',
-                           "ROS_PACKAGE_PATH": ":".join([
-                               "/home/ros/src",
-                               "/opt/ros/hydro/share",
-                               "/opt/ros/hydro/stacks",
-                               "/home/ros/user_data/" + user_container_name
-                           ])}
-                    c.create_container('knowrob/hydro-knowrob-daemon',
-                                       detach=True,
-                                       tty=True,
-                                       environment=env,
-                                       volumes=['/etc/rosauth/secret'],
-                                       name=user_container_name)
-
-                if not user_data_cont_exists:
-                    c.create_container('knowrob/user_data', detach=True, tty=True, name=user_data_container_name,
-                                       entrypoint='true')
-                    c.start(user_data_container_name)
-
-                if not common_data_exists:
-                    c.create_container('knowrob/knowrob_data', detach=True, name=common_data_container_name,
-                                       entrypoint='true')
-                    c.start(common_data_container_name)
-
-                if not mongo_cont_exists:
-                    c.create_container('busybox', detach=True, name='mongo_data', volumes=['/data/db'],
-                                       entrypoint='true')
-                    c.create_container('mongo', detach=True, ports=[27017], name='mongo_db')
-                    c.start('mongo', port_bindings={27017: 27017}, volumes_from=['mongo_data'])
-
-                c.start(user_container_name,
-                        binds={'/home/ros/user_data/secret': {'bind': '/etc/rosauth/secret', 'ro': True}},
-                        port_bindings={9090: None},
-                        links={('mongo_db', 'mongo')},
-                        volumes_from=[user_data_container_name,
-                                      common_data_container_name])
-
-        except APIError, e:
-            print "APIError:" + str(e.message) + "\n"
-            traceback.print_exc()
-        except ConnectionError, e:
-            print "ConnectionError during disconnect:" + str(e.message) + "\n"
+        dockermanager.start_container(user_container_name, user_data_container_name, common_data_container_name)
+        timeout.setTimeout(user_container_name, 600)
 
     @pyjsonrpc.rpcmethod
     def stop_container(self, user_container_name):
-
-        try:
-            c = docker_connect()
-
-            if c is not None:
-                all_containers = c.containers(all=True)
-
-                # check if containers exist:
-                user_cont_exists = False
-
-                for cont in all_containers:
-                    if "/" + user_container_name in cont['Names']:
-                        user_cont_exists = True
-
-                if user_cont_exists:
-                    c.stop(user_container_name, timeout=5)
-
-                    c.remove_container(user_container_name)
-
-        except ConnectionError, e:
-            print "ConnectionError during disconnect:" + str(e.message) + "\n"
+        dockermanager.stop_container(user_container_name)
+        timeout.remove(user_container_name)
 
     @pyjsonrpc.rpcmethod
     def get_container_ip(self, user_container_name):
-        try:
-            c = docker_connect()
+        return dockermanager.get_container_ip(user_container_name)
 
-            if c is not None:
-                inspect = c.inspect_container(user_container_name)
-                return inspect['NetworkSettings']['IPAddress']
-        except:
-            return 'error'
+    @pyjsonrpc.rpcmethod
+    def refresh(self, user_container_name):
+        timeout.resetTimeout(user_container_name, 600)
 
     @pyjsonrpc.rpcmethod
     def get_container_log(self, user_container_name):
-        try:
-            c = docker_connect()
-            logger = c.logs(user_container_name, stdout=True, stderr=True, stream=False, timestamps=False)
-            logstr = ""
-            # TODO: limit number of lines!
-            # It seems for a long living container the log gets to huge.
-            for line in logger:
-                logstr += line
-            return logstr
-        except:
-            return 'error'
+        return dockermanager.get_container_log(user_container_name)
+
 
 def handler(signum, frame):
     sys.exit(0)
@@ -149,8 +46,16 @@ def handler(signum, frame):
 signal.signal(signal.SIGTERM, handler)
 signal.signal(signal.SIGINT, handler)
 
+dockermanager = DockerManager()
+
+sysout("Starting watchdog")
+timeout = TimeoutManager(5, dockermanager.stop_container)
+timeout.start()
+
 http_server = pyjsonrpc.ThreadingHttpServer(
     server_address=('0.0.0.0', 5001),
     RequestHandlerClass=DockerBridge
 )
+
+sysout("Starting JSONRPC")
 http_server.serve_forever()

--- a/dockerbridge/dockermanager.py
+++ b/dockerbridge/dockermanager.py
@@ -1,0 +1,132 @@
+"""
+The DockerManager handles all communication with docker api and provides an API for all actions webrob need to perform
+with the docker host.
+"""
+import docker
+from docker.errors import *
+import traceback
+from utils import sysout
+
+
+class DockerManager(object):
+    @staticmethod
+    def __docker_connect():
+        c = docker.Client(base_url='unix://var/run/docker.sock', version='1.12', timeout=10)
+        return c
+
+    def start_container(self, user_container_name, user_data_container_name, common_data_container_name):
+        try:
+            c = self.__docker_connect()
+
+            if c is not None:
+
+                all_containers = c.containers(all=True)
+
+                # check if containers exist:
+                user_cont_exists = False
+                user_data_cont_exists = False
+                common_data_exists = False
+                mongo_cont_exists = False
+
+                for cont in all_containers:
+                    if "/" + user_container_name in cont['Names']:
+                        user_cont_exists = True
+                    if "/" + user_data_container_name in cont['Names']:
+                        user_data_cont_exists = True
+                    if "/" + common_data_container_name in cont['Names']:
+                        common_data_exists = True
+                    if "/mongo_db" in cont['Names']:
+                        mongo_cont_exists = True
+
+                # Create containers if they do not exist yet
+                if not user_cont_exists:
+                    sysout("Creating user container " + user_container_name)
+                    env = {"VIRTUAL_HOST": user_container_name,
+                           "VIRTUAL_PORT": '9090',
+                           "ROS_PACKAGE_PATH": ":".join([
+                               "/home/ros/src",
+                               "/opt/ros/hydro/share",
+                               "/opt/ros/hydro/stacks",
+                               "/home/ros/user_data/" + user_container_name
+                           ])}
+                    c.create_container('knowrob/hydro-knowrob-daemon',
+                                       detach=True,
+                                       tty=True,
+                                       environment=env,
+                                       name=user_container_name)
+
+                if not user_data_cont_exists:
+                    sysout("Creating user_data container.")
+                    c.create_container('knowrob/user_data', detach=True, tty=True, name=user_data_container_name,
+                                       entrypoint='true')
+                    c.start(user_data_container_name)
+
+                if not common_data_exists:
+                    sysout("Creating knowrob_data container.")
+                    c.create_container('knowrob/knowrob_data', detach=True, name=common_data_container_name,
+                                       entrypoint='true')
+                    c.start(common_data_container_name)
+
+                if not mongo_cont_exists:
+                    sysout("Creating mongo container.")
+                    c.create_container('busybox', detach=True, name='mongo_data', volumes=['/data/db'],
+                                       entrypoint='true')
+                    c.create_container('mongo', detach=True, ports=[27017], name='mongo_db')
+                    c.start('mongo', port_bindings={27017: 27017}, volumes_from=['mongo_data'])
+
+                sysout("Starting user container " + user_container_name)
+                c.start(user_container_name,
+                        port_bindings={9090: None},
+                        links={('mongo_db', 'mongo')},
+                        volumes_from=[user_data_container_name,
+                                      common_data_container_name])
+        except (APIError, DockerException), e:
+            sysout("Error:" + str(e.message) + "\n")
+            traceback.print_exc()
+
+    def stop_container(self, user_container_name):
+        try:
+            c = self.__docker_connect()
+
+            if c is not None:
+                all_containers = c.containers(all=True)
+
+                # check if containers exist:
+                user_cont_exists = False
+
+                for cont in all_containers:
+                    if "/" + user_container_name in cont['Names']:
+                        user_cont_exists = True
+
+                if user_cont_exists:
+                    sysout("Stopping container " + user_container_name + "...\n")
+                    c.stop(user_container_name, timeout=5)
+
+                    sysout("Removing container " + user_container_name + "...\n")
+                    c.remove_container(user_container_name)
+        except (APIError, DockerException), e:
+            sysout("Error:" + str(e.message) + "\n")
+
+    def get_container_ip(self, user_container_name):
+        try:
+            c = self.__docker_connect()
+
+            if c is not None:
+                inspect = c.inspect_container(user_container_name)
+                return inspect['NetworkSettings']['IPAddress']
+        except (APIError, DockerException), e:
+            return 'error'
+
+    def get_container_log(self, user_container_name):
+        try:
+            c = self.__docker_connect()
+            logger = c.logs(user_container_name, stdout=True, stderr=True, stream=False, timestamps=False)
+            logstr = ""
+            # TODO: limit number of lines!
+            # It seems for a long living container the log gets to huge.
+            for line in logger:
+                logstr += line
+            return logstr
+        except (APIError, DockerException), e:
+            sysout("Error:" + str(e.message) + "\n")
+            return 'error'

--- a/dockerbridge/timeoutmanager.py
+++ b/dockerbridge/timeoutmanager.py
@@ -1,0 +1,48 @@
+"""
+A generic timeout mechanism for multiple clients. Initialize with TimeoutManager(interval_in_seconds, callback).
+When started, the manager will check every interval_in_seconds seconds, if any client ran into a timeout. If a client
+ran into a timeout, the manager will call the callback function with the client name as argument. Start the manager with
+start(), set the timeout for a client with setTimeout(client, seconds_from_now), or remove the timeout for a client with
+remove(client). You can reset the timeout for a client by calling resetTimeout, this will refresh the timeout, if a
+timeout was previously assigned to that client.
+"""
+
+from thread import start_new_thread
+from time import sleep, time
+from utils import sysout
+
+__author__ = 'mhorst@cs.uni-bremen.de'
+
+
+class TimeoutManager(object):
+    def __init__(self, interval, callbackFunc):
+        self.interval = interval
+        self.callbackFunc = callbackFunc
+
+    clients = dict()
+
+    def start(self):
+        return start_new_thread(self.__watchdog, ())
+
+    def setTimeout(self, name, seconds):
+        self.clients[name] = time() + seconds
+        sysout('Timeout added for '+name+', terminating in '+str(seconds)+' seconds')
+
+    def resetTimeout(self, name, seconds):
+        if name in self.clients:
+            self.clients[name] = time() + seconds
+            sysout('Timeout reset for '+name+', terminating in '+str(seconds)+' seconds')
+
+    def remove(self, name):
+        if name in self.clients:
+            del self.clients[name]
+
+    def __watchdog(self):
+        while True:
+            currenttime = time()
+            for name, timeleft in self.clients.copy().iteritems():
+                if timeleft < currenttime:
+                    self.callbackFunc(name)
+                    self.remove(name)
+                    sysout('Timeout reached for ' + name)
+            sleep(self.interval)

--- a/dockerbridge/utils.py
+++ b/dockerbridge/utils.py
@@ -1,0 +1,16 @@
+"""
+Holds some utility methods for dockerbridge
+"""
+__author__ = 'mhorst@cs.uni-bremen.de'
+import sys
+
+out = sys.stdout
+
+
+def sysout(msg):
+    """
+    Handles logging output, because pyjsonrpc hijacks stdout.
+    :param msg: Message to print
+    """
+    out.write(msg + "\n")
+    out.flush()

--- a/webrob/webrob/docker/knowrob_docker.py
+++ b/webrob/webrob/docker/knowrob_docker.py
@@ -75,3 +75,16 @@ def get_container_log(user_container_name):
     except URLError, e:
         flash("Error: Connection to your KnowRob instance failed.")
         app.logger.error("ConnectionError during connect: " + str(e) + "\n")
+
+
+def refresh(user_container_name):
+    try:
+        c = docker_connect()
+        if c is not None:
+            return c.notify("refresh", user_container_name)
+    except InternalError, e:
+        flash("Error: Connection to your KnowRob instance failed.")
+        app.logger.error("ConnectionError during connect: " + str(e.message) + str(e.data) + "\n")
+    except URLError, e:
+        flash("Error: Connection to your KnowRob instance failed.")
+        app.logger.error("ConnectionError during connect: " + str(e) + "\n")

--- a/webrob/webrob/pages/api.py
+++ b/webrob/webrob/pages/api.py
@@ -23,6 +23,18 @@ def login_by_session():
     return jsonify({'error': 'not authenticated'})
 
 
+@app.route('/api/v1.0/refresh_by_session', methods=['GET'])
+def refresh_by_session():
+    """
+    Refreshes the running session for a currently logged in user. This prevents a users container from being terminated
+    automatically.
+    """
+    if current_user.is_authenticated():
+        knowrob_docker.refresh(current_user.username)
+        return jsonify({'result': 'success'})
+    return jsonify({'error': 'not authenticated'})
+
+
 @app.route('/api/v1.0/auth_by_token/<string:token>', methods=['GET'])
 def login_by_token(token):
     """
@@ -60,6 +72,19 @@ def stop_container(token):
     if user is None:
         return jsonify({'error': 'wrong api token'})
     knowrob_docker.stop_container(user.username)
+    return jsonify({'result': 'success'})
+
+
+@app.route('/api/v1.0/refresh_by_token/<string:token>', methods=['GET'])
+def refresh_by_token(token):
+    """
+    Refreshes the running session for the user assigned to the given API token. This prevents a users container from
+    being terminated automatically.
+    """
+    user = user_by_token(token)
+    if user is None:
+        return jsonify({'error': 'wrong api token'})
+    knowrob_docker.refresh(user.username)
     return jsonify({'result': 'success'})
 
 

--- a/webrob/webrob/templates/knowrob.html
+++ b/webrob/webrob/templates/knowrob.html
@@ -82,7 +82,17 @@
             meshPath: '/meshes/'
       });
       knowrob.init();
+      container_refresh();
     });
+    function container_refresh() {
+        $.ajax({
+            url: '/api/v1.0/refresh_by_session',
+            type: "GET",
+            contentType: "application/json",
+            dataType: "json"
+        });
+        setTimeout(container_refresh, 570000);
+    };
   </script>
 {% endblock %}
 


### PR DESCRIPTION
This will automatically terminate user containers 10 minutes after the last contact.
It will prevent containers from running indefinitely when a user doesn't log out.
Both the main javascript client and the java client will reset the timer every 9 1/2 minutes automatically, so no container will be terminated if there is still an open browser connected to it.