### PR TITLE
Use tornado as production server

### DIFF
--- a/webapps/easeapp/Dockerfile
+++ b/webapps/easeapp/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Moritz Tenorth, moritz@tenorth.de
 RUN apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -q curl python-all python-pip python-dev wget gcc imagemagick
 
-RUN pip install Flask Flask-Misaka flask-user flask-babel flask-mail psycopg2 python-jsonrpc
+RUN pip install Flask Flask-Misaka flask-user flask-babel flask-mail psycopg2 python-jsonrpc tornado
 WORKDIR /opt/webapp
 
 # flag used in nginx configuration

--- a/webapps/easeapp/runserver.py
+++ b/webapps/easeapp/runserver.py
@@ -4,10 +4,18 @@
 
 from webrob.app_and_db import app, db
 from webrob.startup.init_app import init_app
+from tornado.wsgi import WSGIContainer
+from tornado.httpserver import HTTPServer
+from tornado.ioloop import IOLoop
 
 init_app(app, db)
 
 # Start a development web server if executed from the command line
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0')
+    if 'DEBUG' in app.config and app.config['DEBUG']:
+        app.run(host='0.0.0.0')
+    else:
+        http_server = HTTPServer(WSGIContainer(app))
+        http_server.listen(5000)
+        IOLoop.instance().start()


### PR DESCRIPTION
Usage of internal server is discouraged: http://flask.pocoo.org/docs/0.10/deploying/ and https://stackoverflow.com/questions/12269537/safe-to-deploy-flask-frameworks-webserver-in-a-production-environment
Internal server will automatically be used when run in debug mode (see following PRs).