### PR TITLE
Autogenerated secret for production and debug option for start-webrob

### DIFF
--- a/dockerbridge/dockermanager.py
+++ b/dockerbridge/dockermanager.py
@@ -2,6 +2,7 @@
 The DockerManager handles all communication with docker api and provides an API for all actions webrob need to perform
 with the docker host.
 """
+import os
 import traceback
 
 import docker
@@ -110,8 +111,8 @@ class DockerManager(object):
                 sysout("Creating webapp container " + container_name + " for image " + webapp_image)
                 env = {"VIRTUAL_HOST": container_name,
                        "VIRTUAL_PORT": '5000',
-                       "OPEN_EASE_WEBAPP": 'true'}
-                
+                       "OPEN_EASE_WEBAPP": 'true',
+                       "EASE_DEBUG": os.environ['EASE_DEBUG']}
                 self.__client.create_container(webapp_image,
                                                detach=True, tty=True, stdin_open=True,
                                                environment=env,
@@ -123,6 +124,7 @@ class DockerManager(object):
                 img_env = dict(map(lambda x: x.split("="), inspect['Config']['Env']))
                 links = map(lambda x: tuple(x.split(':')), img_env['DOCKER_LINKS'].split(' '))
                 volumes = img_env['DOCKER_VOLUMES'].split(' ')
+                volumes.append('ease_secret:ro')
                 volumes.append('lft_data')
                 
                 sysout("Running webapp container " + container_name)

--- a/openease_storage_concept.txt
+++ b/openease_storage_concept.txt
@@ -35,6 +35,10 @@ The openEASE platform uses the following host directories and files:
 		- /home/ros/knowrob_data
 		Used for common data files needed in every user container and the easeapp containers, like common experiment data.
 		Used by: easeapp/knowrob container and (read-only) all easeapp/knowrob user containers.
+	ease_secret
+		- /etc/ease_secret
+		Used for storing the SECRET_KEY for the flask session.
+		Used by: All easeapp containers (read only).
 	lft_data
 		- /tmp/openEASE/dockerbridge
 		A folder, where easeapp containers temporarily stores large files and folders. Transfers of large files from the user data containers to the easeapp containers and back will are stored here.

--- a/scripts/start-webrob
+++ b/scripts/start-webrob
@@ -11,7 +11,7 @@ function runContainer {
   RUNNING=$(docker inspect --format="{{ .State.Running }}" $1 2>/dev/null)
   if [ $? -eq 1 ] || [ "$RUNNING" == '<no value>' ]; then # container does not exist
     echo "No $1 container exists, creating a new one..."
-    docker run --name $1 $2
+    bash -c "docker run --name $1 $2"
   fi
   if [ "$3" == true ] && [ "$RUNNING" == 'false' ]; then # container exists, but stopped
     echo "$1 container exists, starting it..."
@@ -32,6 +32,12 @@ function stopContainer {
 if [ -z "$KNOWROB_WEB_PORT" ]
 then
    export KNOWROB_WEB_PORT=5000
+fi
+
+if [ "$1" == "debug" ]; then
+  EASE_DEBUG=true
+else
+  EASE_DEBUG=false
 fi
 
 # Stop all webapp containers
@@ -90,14 +96,20 @@ runContainer "user_db" "-v /var/lib/postgresql/data knowrob/user_db true"
 runContainer "postgres_db" "-d -e POSTGRES_USER=docker --volumes-from user_db knowrob/postgres" true
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-# Check if dockerbridge is running or stopped and start otherwise
-runContainer "dockerbridge" "-d -v /var/run/docker.sock:/var/run/docker.sock knowrob/dockerbridge" true
+# Stop any dockerbridge containers and re-create them to reflect changes to EASE_DEBUG immediately
+stopContainer "dockerbridge"
+runContainer "dockerbridge" "-d -v /var/run/docker.sock:/var/run/docker.sock -e EASE_DEBUG=$EASE_DEBUG knowrob/dockerbridge" true
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # start a knowrob container for the tutorials
 runContainer "data_tutorials" "-v /etc/rosauth knowrob/user_data true"
 < /dev/urandom tr -dc _A-Z-a-z-0-9 | head --bytes=16 | docker run --rm -i --volumes-from data_tutorials busybox sh -c 'cat > /etc/rosauth/secret'
 runContainer "tutorials" "-d -e VIRTUAL_HOST=tutorials -e VIRTUAL_PORT=9090 --volumes-from data_tutorials --volumes-from knowrob_data:ro --link mongo_db:mongo knowrob/hydro-knowrob-daemon" true
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# start a container for the flask secret
+runContainer "ease_secret" "-v /etc/ease_secret busybox sh -c '< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c 64 > /etc/ease_secret/secret'"
 
 # Wait for the postgres port to be available
 echo "Waiting for postgres container..."
@@ -121,9 +133,11 @@ fi
 echo "Creating login web app container..."
 docker run --rm -i -p 127.0.0.1:$KNOWROB_WEB_PORT:5000 \
     --volumes-from mesh_data \
+    --volumes-from ease_secret:ro \
     --link postgres_db:postgres \
     --link dockerbridge:dockerbridge \
     -e VIRTUAL_HOST=login \
     -e VIRTUAL_PORT=5000 \
+    -e EASE_DEBUG=$EASE_DEBUG \
     --name login \
     openease/login python runserver.py

--- a/webapps/easeapp/webrob/config/settings.py
+++ b/webapps/easeapp/webrob/config/settings.py
@@ -1,6 +1,6 @@
 import os
 
-SECRET_KEY='\\\xf8\x12\xdc\xf5\xb2W\xd4Lh\xf5\x1a\xbf"\x05@Bg\xdf\xeb>E\xd8<'
+DEV_SECRET_KEY='\\\xf8\x12\xdc\xf5\xb2W\xd4Lh\xf5\x1a\xbf"\x05@Bg\xdf\xeb>E\xd8<'
 
 SQLALCHEMY_DATABASE_URI = 'postgresql://docker@' + \
     os.environ['POSTGRES_PORT_5432_TCP_ADDR'] + ':' + \

--- a/webapps/easeapp/webrob/startup/init_app.py
+++ b/webapps/easeapp/webrob/startup/init_app.py
@@ -7,9 +7,11 @@
 
 
 from logging.handlers import SMTPHandler
+import os
 from flask_mail import Mail
 from flask_user import UserManager, SQLAlchemyAdapter
 from flask.ext.babel import Babel
+from webrob.pages.utility import random_string
 
 from webrob.startup.init_db import *
 from webrob.pages.routes import register_routes
@@ -21,6 +23,14 @@ def init_app(app, db, extra_config_settings={}):
     app.config.update(extra_config_settings)                # Overwrite with 'extra_config_settings' parameter
     if app.testing:
         app.config['WTF_CSRF_ENABLED'] = False              # Disable CSRF checks while testing
+    if os.environ['EASE_DEBUG'] == 'true':
+        app.config['DEBUG'] = True
+        app.config['SECRET_KEY'] = app.config['DEV_SECRET_KEY']
+    else:
+        try:
+            app.config['SECRET_KEY'] = open('/etc/ease_secret/secret', 'rb').read()
+        except IOError:
+            app.config['SECRET_KEY'] = random_string(64)
 
     # Setup Flask-Mail
     mail = Mail(app)


### PR DESCRIPTION
This will make all easeapps use an autogenerated, file-based secret from the ease_secret data-container instead of the hardcoded, public one in settings.py.
This is important because flask uses the secret to sign the session data stored on the client as a cookie. If the user knows the secret, he could manipulate the session by signing his changes to the session cookie himself.

Also, a debug argument is added to the start-webrob script.
Calling ```./start-webrob debug ``` will start all easeapps in debug mode and will use the internal flask server (see #36).