### PR TITLE
Resource limits for user containers + small fixes.

### DIFF
--- a/nginx-proxy/nginx.tmpl
+++ b/nginx-proxy/nginx.tmpl
@@ -14,6 +14,9 @@ map $http_upgrade $proxy_connection {
 
 gzip_types text/plain text/css application/javascript application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
 
+# Maximum upload size (affects size of text a user can type in the editor). Default is 1 MB
+client_max_body_size 20M;
+
 log_format vhost '$host $remote_addr - $remote_user [$time_local] '
                  '"$request" $status $body_bytes_sent '
                  '"$http_referer" "$http_user_agent"';

--- a/webapps/knowrob/webrob/templates/knowrob.html
+++ b/webapps/knowrob/webrob/templates/knowrob.html
@@ -64,9 +64,9 @@
   <script type="text/javascript" src="{{ url_for('static', filename='lib/knowrob.js') }}"></script>
   <script type="text/javascript" src="{{ url_for('static', filename='lib/html2canvas.js') }}"></script>
   <script type="text/javascript" src="{{ url_for('static', filename='lib/FileSaver.js') }}"></script>
-  <script type="text/javascript" src="http://gabelerner.github.io/canvg/rgbcolor.js"></script> 
-  <script type="text/javascript" src="http://gabelerner.github.io/canvg/StackBlur.js"></script>
-  <script type="text/javascript" src="http://gabelerner.github.io/canvg/canvg.js"></script> 
+  <script type="text/javascript" src="//gabelerner.github.io/canvg/rgbcolor.js"></script>
+  <script type="text/javascript" src="//gabelerner.github.io/canvg/StackBlur.js"></script>
+  <script type="text/javascript" src="//gabelerner.github.io/canvg/canvg.js"></script>
   <script type="text/javascript">
     // global knowrob handle
     var knowrob;


### PR DESCRIPTION
Introduce resource limits for user containers.
Increase maximum upload size for the editor to 20 MB.
Use secure connections when using TLS.